### PR TITLE
Make domain a configurable variable. Improve request error logging.  Support unverified from option to facilitate Webform emails.

### DIFF
--- a/mailgun.admin.inc
+++ b/mailgun.admin.inc
@@ -50,18 +50,29 @@ function mailgun_admin_settings($form, &$form_state) {
       '#collapsible' => TRUE,
       '#title' => t('Email options'),
     );
+
     $form['email_options']['mailgun_from'] = array(
       '#title' => t('From address'),
       '#type' => 'textfield',
       '#description' => t('The sender email address. If this address has not been verified, messages will be queued and not sent until it is.'),
       '#default_value' => variable_get('mailgun_from', variable_get('site_mail'))
     );
+
     $form['email_options']['mailgun_from_name'] = array(
       '#type' => 'textfield',
       '#title' => t('From name'),
       '#default_value' => variable_get('mailgun_from_name', ''),
       '#description' => t('Optionally enter a from name to be used.'),
     );
+
+    $form['email_options']['mailgun_verify_from'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Only send emails with this From address'),
+      '#description' => t('If enabled, Mailgun will not send emails whose ' .
+        'From address is different than this email address.'),
+      '#default_value' => variable_get('mailgun_verify_from', FALSE),
+    );
+
 
     $formats = filter_formats();
     $options = array('' => t('-- Select --'));
@@ -179,12 +190,10 @@ function mailgun_admin_settings_submit($form, &$form_state) {
  * @return array $form
  */
 function mailgun_test_form($form, &$form_state) {
-  drupal_set_title(t('Send test email'));
-
   $form['mailgun_test_address'] = array(
     '#type' => 'textfield',
     '#title' => t('Email address to send a test email to'),
-    '#default_value' => 'rebol@126.com',//variable_get('site_mail', ''),
+    '#default_value' => variable_get('site_mail', ''),
     '#description' => t('Type in an address to have a test email sent there.'),
     '#required' => TRUE
   );

--- a/mailgun.admin.inc
+++ b/mailgun.admin.inc
@@ -14,14 +14,22 @@
 function mailgun_admin_settings($form, &$form_state) {
   $key = variable_get('mailgun_api_key');
   $form['mailgun_api_key'] = array(
-    '#title' => t('mailgun API Key'),
+    '#title' => t('Mailgun API Key'),
     '#type' => 'textfield',
     '#description' => t('Create or grab your API key from the !link.',
       array('!link' => l('mailgun settings', 'http://www.mailgun.com/'))),
-    '#default_value' => $key
+    '#default_value' => $key,
   );
 
-  if ($key) {
+  $domain = variable_get('mailgun_domain');
+  $form['mailgun_domain'] = array(
+    '#title' => t('Mailgun Domain'),
+    '#type' => 'textfield',
+    '#description' => t('Domain for sending mail'),
+    '#default_value' => $domain,
+  );
+
+  if ($key && $domain) {
     $form['mailgun_status'] = array(
       '#type' => 'radios',
       '#title' => t('mailgun Mail interface status'),

--- a/mailgun.class.php
+++ b/mailgun.class.php
@@ -14,11 +14,11 @@ class MailGun {
 
   function __construct($api_key, $domain, $timeout = 300) {
     if (empty($api_key)) {
-      throw new mailgun_Exception('Invalid API key');
+      throw new Mailgun_Exception('Invalid API key');
     }
 
     if (empty($domain)) {
-      throw new mailgun_Exception('Invalid domain');
+      throw new Mailgun_Exception('Invalid domain');
     }
 
     try {

--- a/mailgun.class.php
+++ b/mailgun.class.php
@@ -4,33 +4,36 @@ class MailGun_Exception extends Exception {
 }
 
 class MailGun {
-  //const API_VERSION = '1.0';
-  const END_POINT = 'https://api.mailgun.net/v2/yhmyt.mailgun.org';//'https://mailgunapp.com/api/';
-
   var $api;
+  var $endpoint;
 
   /**
    * Default to a 300 second timeout on server calls
    */
   var $timeout = 300;
 
-  function __construct($api_key, $timeout = 300) {
+  function __construct($api_key, $domain, $timeout = 300) {
     if (empty($api_key)) {
       throw new mailgun_Exception('Invalid API key');
     }
-    try {
-			$this->api = $api_key;
 
-      $response = $this->request('log',array(),'GET');
+    if (empty($domain)) {
+      throw new mailgun_Exception('Invalid domain');
+    }
+
+    try {
+      $this->api = $api_key;
+      $this->endpoint = 'https://api.mailgun.net/v2/' . $domain;
+
+      $response = $this->request('log', array(), 'GET');
       if (!isset($response['total_count'])) {
         throw new MailGun_Exception('Invalid API key');
       }
 
-
       $this->timeout = $timeout;
 
     } catch (Exception $e) {
-			watchdog('mailgun', $e->getMessage());
+      watchdog('mailgun', $e->getMessage());
       throw new MailGun_Exception($e->getMessage());
     }
   }
@@ -87,8 +90,7 @@ class MailGun {
     //$api_version = self::API_VERSION;
     //$dot_output = ('json' == $output) ? '' : ".{$output}";
 
-    //$url = self::END_POINT . "{$api_version}/{$method}{$dot_output}";
-		$url = self::END_POINT. "/{$method}";
+    $url = $this->endpoint . "/{$method}";
     //$params = drupal_json_encode($args);
 		//$params = drupal_http_build_query($args);
 		$boundary = 'A0sFSD';
@@ -140,7 +142,7 @@ class MailGun {
     }
     else {
       $message = isset($body['message']) ? $body['message'] : '';
-      throw new MailGun_Exception($message . ' - ' . $body, $response_code);
+      throw new MailGun_Exception("Receiving $response_code for url $url: $message - $body");
     }
   }
 

--- a/mailgun.mail.inc
+++ b/mailgun.mail.inc
@@ -40,15 +40,13 @@ class MailGunMailSystem implements MailSystemInterface {
    *   TRUE if the mail was successfully accepted, otherwise FALSE.
    */
   public function mail(array $message) {
-		if (!$from = variable_get('mailgun_from', '')) {
-      drupal_set_message(t('mailgun can\'t send email. Please !link.',
-        array(
-          '!link' => l('add a verified from address',
-            'admin/config/services/mailgun'
-          )
-        )
-      ), 'error');
-      return FALSE;
+    $from = $message['from'];
+    if (variable_get('mailgun_verify_from')) {
+      if ($from != variable_get('mailgun_from', '')) {
+        watchdog('mailgun', 'Email sent from unverified address: @from',
+          array('@from' => $from));
+        return FALSE;
+      }
     }
 
     // send the email passing the message id as the tag for use in reporting
@@ -96,7 +94,7 @@ class MailGunMailSystem implements MailSystemInterface {
       /*'attachments'*/
       //'view_content_link' => $view_content
     );
-				
+
 		if (isset($message['attachments']) && !empty($message['attachments'])) {
 			$i = 1;
       foreach ($message['attachments'] as $attachment) {
@@ -109,8 +107,8 @@ class MailGunMailSystem implements MailSystemInterface {
 
 		if(isset($message['bcc_email'])) {
 			$mailgun_message['bcc'] = $message['bcc_email'];
-		}	
-		
+		}
+
     drupal_alter('mailgun_mail', $mailgun_message, $message);
 
     try {

--- a/mailgun.module
+++ b/mailgun.module
@@ -29,7 +29,7 @@ function mailgun_help($path, $arg) {
  */
 function mailgun_menu() {
   $items['admin/config/services/mailgun'] = array(
-    'title' => 'mailgun',
+    'title' => 'Mailgun',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('mailgun_admin_settings'),
     'access arguments' => array('administer mailgun'),
@@ -37,11 +37,13 @@ function mailgun_menu() {
     'file' => 'mailgun.admin.inc',
     'type' => MENU_NORMAL_ITEM,
   );
+
   $items['admin/config/services/mailgun/settings'] = array(
     'title' => 'Settings',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => 0
   );
+
   $items['admin/config/services/mailgun/test'] = array(
     'title' => 'Send test email',
     'page callback' => 'drupal_get_form',

--- a/mailgun.module
+++ b/mailgun.module
@@ -118,11 +118,12 @@ function mailgun_get_tags() {
  */
 function mailgun_get_api_object() {
   $api_key = variable_get('mailgun_api_key', '');
-  if (empty($api_key)) {
+  $domain = variable_get('mailgun_domain', '');
+  if (empty($api_key) || empty($domain)) {
     return FALSE;
   }
 
-  $api = new MailGun($api_key, 60);
+  $api = new MailGun($api_key, $domain, 60);
 
   return $api;
 }
@@ -135,3 +136,4 @@ function mailgun_get_api_object() {
 function mailgun_mail_key_blacklist() {
   return variable_get('mailgun_mail_key_blacklist', 'user_password_reset');
 }
+


### PR DESCRIPTION
I thought this module was extremely useful and I'd love to see it made more available generally as a Drupal module.  This PR makes it possible for admins to configure their own email send domain, which seems like an important step in that direction, but I'd be happy to help out with other items that would be useful here.
